### PR TITLE
Diverse wijzingen podcastlinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,8 @@
   <section class="Section" id="Luister_naar_een_aflevering">
 
       <a href="#Luister_naar_een_aflevering" class="hidden"><h1 class="Section_heading">Luister naar een aflevering</h1></a>
-      <p class="Section_paragraph">Afleveringen van De Bitcoin Show zijn te vinden op <a href="https://www.youtube.com/channel/UCP-WQVY-xo2bvOIiN9Q-qig">Youtube</a> en alle populaire podcastkanalen (bijvoorbeeld op <a href="https://anchor.fm/debitcoinshow">Anchor FM</a>).</p>
+      <p class="Section_paragraph">Video's van de afleveringen van De Bitcoin Show zijn te vinden op <a href="https://bitcointv.com/video-channels/de_bitcoin_show/">BitcoinTV.com</a> en alle populaire podcastkanalen (bijvoorbeeld op <a href="https://podcastindex.org/podcast/909870">Podcastindex.org</a> en <a href="https://anchor.fm/debitcoinshow">Anchor FM</a>).</p>
+      <p class="Section_paragraph">Podcastindex.org vermeldt <a href="https://podcastindex.org/podcast/value4value">verschillende wallets</a> waarmee je sats kan doneren tijdens het luisteren als je dat wilt.</p>
       <p class="Section_paragraph">Zie hieronder de eerste aflevering, "The Genesis Pod", onze aflevering met Plan B en onze laatste aflevering.</p>
       <div class="Aflevering">
         <iframe src="https://anchor.fm/debitcoinshow/embed/episodes/Episode-1-The-Genesis-Pod-e52bpb/a-aleblo" height="102px" width="330px" frameborder="0" scrolling="no"></iframe>
@@ -150,10 +151,6 @@
         <li>
           <p class="socicon-mail" style="color:#000">&#xe050;</p>
           <a href="mailto:hello@debitcoinshow.nl">Mail</a>
-        </li>
-        <li>
-          <p class="socicon-youtube" style="color:#e02a20">&#xe0a5;</p>
-          <a href="https://www.youtube.com/channel/UCP-WQVY-xo2bvOIiN9Q-qig" target="_blank">YouTube</a>
         </li>
         <li>
           <p class="socicon-rss" style="color:#f26109">&#xe071;</p>


### PR DESCRIPTION
*   Link naar Youtubekanaal in tekst verwijderd en kanaal DBS op BitcoinTV.com op die plaats gezet
*   Link naar Podcastindex.org van Curry toegevoegd, aangezien Boris deze altijd vermeld
*   Link naar info over sats streamen op Podcastindex.org toegevoegd, plus wat tekst.
*   Link naar Youtube social icon verwijdert in het lijstje twitter, reddit etcetera. De smeerlappen.