### PR TITLE
Telegram links via t.me en niet via telegram.im

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
         </li>
         <li>
           <p class="socicon-telegram" style="color:#4da7de">&#xe087;</p>
-          <a href="https://telegram.im/@debitcoinshow" target="_blank">Telegram Ontopic</a> / <a href="https://telegram.im/@debitcoinshowofftopic">Offtopic</a> chat
+          <a href="https://t.me/debitcoinshow" target="_blank">Telegram Ontopic</a> / <a href="https://t.me/debitcoinshowofftopic">Offtopic</a> chat
         </li>
         <li>
           <p class="socicon-telegram" style="color:#4da7de">&#xe087;</p>


### PR DESCRIPTION
Wijzig gedaan aan de links onderaan op de pagina. De links naar de telegram groepen gaan via Telegram.im en niet via t.me in de huidige versie. Telegram.im is geen officiële service van telegram zelf en komt wat vaag over.