### PR TITLE
Remove reference to non-existing Prociono.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
 
   <link rel="canonical" href="https://www.debitcoinshow.nl">
   <link href="CSS/debitcoinshow.css" rel="stylesheet" type="text/css">
-  <link href="CSS/Prociono.css" rel="stylesheet">
 
   <meta property="og:title" content="De Bitcoin Show!">
   <meta property="og:url" content="https://www.debitcoinshow.nl">


### PR DESCRIPTION
In commit 51a7aff1, the file Prociono.css was removed (and merged with
"debitcoinshow.css"), but the reference in index.html was not removed.

- Remove Prociono.css reference from index.html